### PR TITLE
update package.json for resolve throw error in deprecated package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "AngularJS-TestingTips",
   "description": "Code for SitePoint Tutorial",
   "devDependencies": {
-    "angular-mocks": "1.3.15",
-    "jasmine-core": "2.2.0",
-    "karma": "0.12.31",
-    "karma-jasmine": "0.3.5",
-    "karma-phantomjs-launcher": "0.1.4"
+    "angular-mocks": "^1.6.10",
+    "jasmine-core": "^3.1.0",
+    "karma": "^2.0.2",
+    "karma-jasmine": "^1.1.1",
+    "karma-phantomjs-launcher": "^1.0.4"
   },
   "dependencies": {
-    "angular": "1.3.15"
+    "angular": "^1.6.10"
   }
 }


### PR DESCRIPTION
Hi,
First of all, thanks for the guide of angular testing project, as I running command from the readme things not going well due to some package deprecated. So I update to the latest versions and it's working good.
`/git/angular-js-unit-testing-services-controllers-providers/node_modules/socket.io/lib/store.
js:35
Store.prototype.__proto__ = EventEmitter.prototype;
                                         ^


TypeError: Cannot read property 'prototype' of undefined
    at Object.<anonymous> (/git/angular-js-unit-testing-services-controllers-providers/node_m
odules/socket.io/lib/store.js:35:42)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
    at Module.require (module.js:593:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/git/angular-js-unit-testing-services-controllers-providers/node_m
odules/socket.io/lib/manager.js:16:13)
    at Module._compile (module.js:649:30)`